### PR TITLE
Add missing trait impls, Clone, PartialEq & Eq for BuildDefaultHasher

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,26 @@ where
     }
 }
 
+impl<H> Clone for BuildHasherDefault<H>
+where
+    H: Default + Hasher,
+{
+    fn clone(&self) -> Self {
+        BuildHasherDefault::default()
+    }
+}
+
+impl<H> PartialEq for BuildHasherDefault<H>
+where
+    H: Default + Hasher,
+{
+    fn eq(&self, _other: &BuildHasherDefault<H>) -> bool {
+        true
+    }
+}
+
+impl<H: Default + Hasher> Eq for BuildHasherDefault<H> {}
+
 impl<H> BuildHasherDefault<H>
 where
     H: Default + Hasher,
@@ -343,7 +363,7 @@ tuple! { A B C D E F G H I J K L }
 
 #[cfg(test)]
 mod test {
-    use super::{Hash, Hasher, FnvHasher};
+    use super::{FnvHasher, Hash, Hasher};
     #[test]
     fn hashes_tuples() {
         let mut h = FnvHasher::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@
 extern crate byteorder;
 
 use core::marker::PhantomData;
-use core::{mem, slice};
+use core::{mem, slice, fmt};
 
 pub use fnv::Hasher as FnvHasher;
 pub use murmur3::Hasher as Murmur3Hasher;
@@ -134,6 +134,12 @@ where
 }
 
 impl<H: Default + Hasher> Eq for BuildHasherDefault<H> {}
+
+impl<H: Default + Hasher> fmt::Debug for BuildHasherDefault<H> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("BuildHasherDefault")
+    }
+}
 
 impl<H> BuildHasherDefault<H>
 where


### PR DESCRIPTION
Ran into this trying to clone a FnvHashmap in heapless.

As per https://doc.rust-lang.org/stable/src/core/hash/mod.rs.html#542, this PR Implements the missing traits that `core::BuildDefaultHasher` has.