### PR TITLE
Update proc macro dependencies.

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -12,6 +12,6 @@ version = "0.1.0"
 proc-macro = true
 
 [dependencies]
-quote = "0.5.2"
-syn = "0.13.1"
-proc-macro2 = "0.3.6"
+quote = "1.0.9"
+syn = "1.0.72"
+proc-macro2 = "1.0.27"


### PR DESCRIPTION
Update quote, syn, proc-macro2 to latest versions and fix breaking changes.

This is needed to derive on a struct using const generics, as the super-old syn can't parse const generics.

```rust
#[derive(Hash32)]
pub struct LinkID {
    inner: heapless::Vec<u8, 12>,
}
```