### PR TITLE
treewide: update URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,10 +56,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/japaric/hash32/compare/v0.3.1...HEAD
-[v0.3.1]: https://github.com/japaric/hash32/compare/v0.3.0...v0.3.1
-[v0.3.0]: https://github.com/japaric/hash32/compare/v0.2.1...v0.3.0
-[v0.2.1]: https://github.com/japaric/hash32/compare/v0.2.0...v0.2.1
-[v0.2.0]: https://github.com/japaric/hash32/compare/v0.1.2...v0.2.0
-[v0.1.2]: https://github.com/japaric/hash32/compare/v0.1.1...v0.1.2
-[v0.1.1]: https://github.com/japaric/hash32/compare/v0.1.0...v0.1.1
+[Unreleased]: https://github.com/rust-embedded-community/hash32/compare/v0.3.1...HEAD
+[v0.3.1]: https://github.com/rust-embedded-community/hash32/compare/v0.3.0...v0.3.1
+[v0.3.0]: https://github.com/rust-embedded-community/hash32/compare/v0.2.1...v0.3.0
+[v0.2.1]: https://github.com/rust-embedded-community/hash32/compare/v0.2.0...v0.2.1
+[v0.2.0]: https://github.com/rust-embedded-community/hash32/compare/v0.1.2...v0.2.0
+[v0.1.2]: https://github.com/rust-embedded-community/hash32/compare/v0.1.1...v0.1.2
+[v0.1.1]: https://github.com/rust-embedded-community/hash32/compare/v0.1.0...v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "32-bit hashing algorithms"
 keywords = ["32-bit", "hash", "fnv", "murmur3"]
 license = "MIT OR Apache-2.0"
 name = "hash32"
-repository = "https://github.com/japaric/hash32"
+repository = "https://github.com/rust-embedded-community/hash32"
 version = "0.3.1"
 
 [dependencies.byteorder]


### PR DESCRIPTION
The repository has moved to the rust-embedded-community. The old URLs still work, but they result in a redirect.