### PR TITLE
examples: remove extern crate

### DIFF
--- a/examples/derive.rs
+++ b/examples/derive.rs
@@ -1,5 +1,3 @@
-extern crate hash32;
-
 use std::hash::Hash;
 
 use hash32::{FnvHasher, Hasher};


### PR DESCRIPTION
This is no longer required with edition 2021