### PR TITLE
CI: add rustdoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,16 @@ jobs:
         with:
           components: clippy
       - run: cargo clippy --all --all-targets -- --deny warnings
+
+  rustdoc:
+    name: rustdoc
+    runs-on: ubuntu-latest
+    env: {"RUSTDOCFLAGS": "-D warnings"}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      # docs.rs builds documentation with:
+      # - nightly rust
+      # - all features
+      # - cargo rustdoc, not cargo doc
+      - run: cargo +nightly rustdoc --all-features


### PR DESCRIPTION
I plan to do some documentation enhancements, adding more examples to follow the [C-EXAMPLE](https://rust-lang.github.io/api-guidelines/documentation.html#c-example) API guideline.

I added the CI check to keep everything happy until then.