### PR TITLE
Move warnings check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,12 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
-
+    env: {"RUSTFLAGS": "-D warnings"}
     strategy:
       matrix:
         target:
           - x86_64-unknown-linux-gnu
           - i686-unknown-linux-musl
-
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,9 +46,8 @@
 //! This crate is guaranteed to compile on latest stable Rust. It *might* compile on older
 //! versions but that may change in any new patch release.
 
-#![deny(missing_docs)]
-#![deny(warnings)]
 #![warn(
+    missing_docs,
     clippy::use_self,
     clippy::doc_markdown,
     clippy::ptr_as_ptr,


### PR DESCRIPTION
During development it can be useful to ignore warnings temporarily. `#![deny(warnings)]` in `lib.rs` prevents this, as it forces all warnings to become errors.

I moved the warnings check into CI to prevent code with warnings from being merged, while still allowing temporary warnings during development.