### PR TITLE
murmur3: remove #[allow(deprecated)]

### DIFF
--- a/src/murmur3.rs
+++ b/src/murmur3.rs
@@ -73,7 +73,6 @@ impl Hasher {
 }
 
 impl Default for Hasher {
-    #[allow(deprecated)]
     fn default() -> Self {
         Self {
             buf: Buffer {


### PR DESCRIPTION
This was added in ea5e2946a17be3bc247ab56d8b14d9b7878e5b66 but does not appear to be necessary anymore.