### PR TITLE
Change struct names to match exported name

### DIFF
--- a/src/fnv.rs
+++ b/src/fnv.rs
@@ -8,24 +8,24 @@ const PRIME: u32 = 0x1000193;
 /// Specifically this implements the [FNV-1a hash].
 ///
 /// [FNV-1a hash]: https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function#FNV-1a_hash
-pub struct Hasher {
+pub struct FnvHasher {
     state: u32,
 }
 
-impl Default for Hasher {
+impl Default for FnvHasher {
     fn default() -> Self {
         Self { state: BASIS }
     }
 }
 
-impl crate::Hasher for Hasher {
+impl crate::Hasher for FnvHasher {
     #[inline]
     fn finish32(&self) -> u32 {
         self.state
     }
 }
 
-impl core::hash::Hasher for Hasher {
+impl core::hash::Hasher for FnvHasher {
     #[inline]
     fn write(&mut self, bytes: &[u8]) {
         for byte in bytes {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,8 @@
 )]
 #![no_std]
 
-pub use crate::fnv::Hasher as FnvHasher;
-pub use crate::murmur3::Hasher as Murmur3Hasher;
+pub use crate::fnv::FnvHasher;
+pub use crate::murmur3::Murmur3Hasher;
 
 mod fnv;
 mod murmur3;

--- a/src/murmur3.rs
+++ b/src/murmur3.rs
@@ -4,7 +4,7 @@ use core::slice;
 use crate::Hasher as _;
 
 /// 32-bit `MurmurHash3` hasher
-pub struct Hasher {
+pub struct Murmur3Hasher {
     buf: Buffer,
     index: Index,
     processed: u32,
@@ -50,7 +50,7 @@ impl From<usize> for Index {
     }
 }
 
-impl Hasher {
+impl Murmur3Hasher {
     /// # Safety
     ///
     /// The caller must ensure that `self.index.usize() + buf.len() <= 4`.
@@ -72,7 +72,7 @@ impl Hasher {
     }
 }
 
-impl Default for Hasher {
+impl Default for Murmur3Hasher {
     fn default() -> Self {
         Self {
             buf: Buffer {
@@ -85,7 +85,7 @@ impl Default for Hasher {
     }
 }
 
-impl crate::Hasher for Hasher {
+impl crate::Hasher for Murmur3Hasher {
     fn finish32(&self) -> u32 {
         // tail
         let mut state = match self.index {
@@ -128,7 +128,7 @@ impl crate::Hasher for Hasher {
     }
 }
 
-impl core::hash::Hasher for Hasher {
+impl core::hash::Hasher for Murmur3Hasher {
     #[inline]
     fn write(&mut self, bytes: &[u8]) {
         let len = bytes.len();


### PR DESCRIPTION
This helps readability to distinguish between the Hasher trait, and the structs that implement the Hasher trait.