### PR TITLE
hashers: derive Debug and Clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added `Debug` implementations to hashers.
+- Added `Clone` implementations to hashers.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Added `Debug` implementations to hashers.
+
 ### Changed
 
 - Updated the edition from 2015 to 2021.
@@ -16,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Removed the `byteorder` dependency.
 - Removed the `BuildHasherDefault` type.
   - This type existed because `core::hash::BuildHasherDefault` did not have a const constructor.
-  - As of 1.85 core::hash::BuildHasherDefault has a const constructor.
+  - As of 1.85 `core::hash::BuildHasherDefault` has a const constructor.
 
 ## [v0.3.1] - 2022-08-09
 

--- a/src/fnv.rs
+++ b/src/fnv.rs
@@ -8,7 +8,7 @@ const PRIME: u32 = 0x1000193;
 /// Specifically this implements the [FNV-1a hash].
 ///
 /// [FNV-1a hash]: https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function#FNV-1a_hash
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FnvHasher {
     state: u32,
 }

--- a/src/fnv.rs
+++ b/src/fnv.rs
@@ -8,6 +8,7 @@ const PRIME: u32 = 0x1000193;
 /// Specifically this implements the [FNV-1a hash].
 ///
 /// [FNV-1a hash]: https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function#FNV-1a_hash
+#[derive(Debug)]
 pub struct FnvHasher {
     state: u32,
 }

--- a/src/murmur3.rs
+++ b/src/murmur3.rs
@@ -4,6 +4,7 @@ use core::slice;
 use crate::Hasher as _;
 
 /// 32-bit `MurmurHash3` hasher
+#[derive(Debug)]
 pub struct Murmur3Hasher {
     buf: Buffer,
     index: Index,
@@ -11,15 +12,16 @@ pub struct Murmur3Hasher {
     state: State,
 }
 
+#[derive(Debug)]
 struct State(u32);
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 #[repr(align(4))]
 struct Buffer {
     bytes: MaybeUninit<[u8; 4]>,
 }
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 enum Index {
     _0,
     _1,

--- a/src/murmur3.rs
+++ b/src/murmur3.rs
@@ -4,7 +4,7 @@ use core::slice;
 use crate::Hasher as _;
 
 /// 32-bit `MurmurHash3` hasher
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Murmur3Hasher {
     buf: Buffer,
     index: Index,
@@ -12,7 +12,7 @@ pub struct Murmur3Hasher {
     state: State,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct State(u32);
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
This follows the C-DEBUG API guideline, and aligns with std::hash::DefaultHasher.